### PR TITLE
Add `-w`/`--wait` & `--random-wait` options which implement rate limiting

### DIFF
--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -34,6 +34,9 @@ option_parser = OptionParser.new do |opts|
     options[:exact_url] = t
   end
 
+  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
+    options[:only_filter] = t
+
   opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
     options[:wait_seconds] = t
   end

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -34,8 +34,12 @@ option_parser = OptionParser.new do |opts|
     options[:exact_url] = t
   end
 
-  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
-    options[:only_filter] = t
+  opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
+    options[:wait_seconds] = t
+  end
+
+  opts.on("--random-wait", "When used with --wait, randomize number of seconds waited between requests by a factor of 0.5 to 2") do |t|
+    options[:wait_randomize] = true
   end
 
   opts.on("-x", "--exclude EXCLUDE_FILTER", String, "Skip downloading of urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -36,6 +36,7 @@ option_parser = OptionParser.new do |opts|
 
   opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
     options[:only_filter] = t
+  end
 
   opts.on("-w", "--wait SECONDS", Integer, "Wait the specified number of seconds between requests") do |t|
     options[:wait_seconds] = t

--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -268,8 +268,7 @@ class WaybackMachineDownloader
         structure_dir_path dir_path
         open(file_path, "wb") do |file|
           begin
-            file_url_escaped = CGI.escape file_url
-            URI.open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url_escaped}", "Accept-Encoding" => "plain") do |uri|
+            URI.open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url}", "Accept-Encoding" => "plain") do |uri|
               file.write(uri.read)
             end
           rescue OpenURI::HTTPError => e

--- a/lib/wayback_machine_downloader.rb
+++ b/lib/wayback_machine_downloader.rb
@@ -268,7 +268,8 @@ class WaybackMachineDownloader
         structure_dir_path dir_path
         open(file_path, "wb") do |file|
           begin
-            open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url}", "Accept-Encoding" => "plain") do |uri|
+            file_url_escaped = CGI.escape file_url
+            URI.open("http://web.archive.org/web/#{file_timestamp}id_/#{file_url_escaped}", "Accept-Encoding" => "plain") do |uri|
               file.write(uri.read)
             end
           rescue OpenURI::HTTPError => e

--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -2,10 +2,10 @@ module ArchiveAPI
 
   def get_raw_list_from_api url, page_index
     request_url = "http://web.archive.org/cdx/search/xd?url="
-    request_url += url
+    request_url += CGI.escape url
     request_url += parameters_for_api page_index
 
-    open(request_url).read
+    URI.open(request_url).read
   end
 
   def parameters_for_api page_index


### PR DESCRIPTION
*IMPORTANT*: _PR #4 is a prerequisite for the PR and should be merged first._

This implements rate limiting (see Issue #1) by adding:

* New `-w`/`--wait` option which accepts a number of seconds to pause/sleep between subsequent requests
* New `--random-wait` option which will cause `-w`/`--wait` seconds to be randomized by 0.5x-2x
* New `WaybackMachineDownloader#wait` method which implements the functionality using the aforementioned options

Specifically, `WaybackMachineDownloader#wait` is called only when requesting additional pages of results in `#get_all_snapshots_to_consider` and before downloading individual files in `#download_files`. This means that the first request of pages to download in not delayed, but all subsequent requests & actual page downloads are delayed.

Example usage:

`./bin/wayback_machine_downloader --to 20120222134837 --wait 300 --random-wait http://www.folklore.org/`

This should pause for a random number of seconds between 150 (2.5 minutes) and 600 (10 minutes) between each request, since it's using both `--wait 300` (5 minutes) and `--random-wait`.